### PR TITLE
use remote schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <mainClass>eu.dissco.dataexporter.maven.MavenRunner</mainClass>
+          <arguments>
+            <argument>https://schemas.dissco.tech/schemas/developer-schema/data-export/0.3.0/data-export-request.json</argument>
+          </arguments>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/eu/dissco/dataexporter/controller/DataExporterController.java
+++ b/src/main/java/eu/dissco/dataexporter/controller/DataExporterController.java
@@ -5,7 +5,7 @@ import eu.dissco.dataexporter.domain.JobResult;
 import eu.dissco.dataexporter.domain.User;
 import eu.dissco.dataexporter.exception.ForbiddenException;
 import eu.dissco.dataexporter.exception.InvalidRequestException;
-import eu.dissco.dataexporter.schema.ExportJobRequest;
+import eu.dissco.dataexporter.schema.DataExportRequest;
 import eu.dissco.dataexporter.service.DataExporterService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class DataExporterController {
 
   @PostMapping("/schedule")
   public ResponseEntity<Void> scheduleJob(Authentication authentication,
-      @RequestBody ExportJobRequest request)
+      @RequestBody DataExportRequest request)
       throws ForbiddenException, InvalidRequestException {
     var user = getUser(authentication);
     service.handleJobRequest(request, user);

--- a/src/main/java/eu/dissco/dataexporter/controller/DataExporterController.java
+++ b/src/main/java/eu/dissco/dataexporter/controller/DataExporterController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/data-export")
+@RequestMapping("/")
 @Slf4j
 @RequiredArgsConstructor
 public class DataExporterController {
 
   private final DataExporterService service;
 
-  @PostMapping("/schedule")
+  @PostMapping("schedule")
   public ResponseEntity<Void> scheduleJob(Authentication authentication,
       @RequestBody DataExportRequest request)
       throws ForbiddenException, InvalidRequestException {
@@ -39,7 +39,7 @@ public class DataExporterController {
     return ResponseEntity.status(HttpStatus.ACCEPTED).build();
   }
 
-  @PostMapping("/internal/{id}/{jobState}")
+  @PostMapping("internal/{id}/{jobState}")
   public ResponseEntity<Void> updateJobState(@PathVariable("id") UUID id,
       @PathVariable("jobState") String jobStateStr) throws InvalidRequestException {
     service.updateJobState(id, getJobState(jobStateStr));
@@ -47,7 +47,7 @@ public class DataExporterController {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
-  @PostMapping(value = "/internal/completed", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(value = "internal/completed", consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> completeJob(@RequestBody JobResult jobResult) {
     service.markJobAsComplete(jobResult);
     log.info("Successfully marked job {} as complete", jobResult.id());

--- a/src/main/java/eu/dissco/dataexporter/maven/MavenRunner.java
+++ b/src/main/java/eu/dissco/dataexporter/maven/MavenRunner.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
@@ -27,15 +29,15 @@ public class MavenRunner {
         String schema = downloadSchema(schemaUrl);
         saveSchemaToFile(schema, outputFilePath);
         LOGGER.info("JSON schema downloaded and saved to: {} ", outputFilePath);
-      } catch (IOException e) {
+      } catch (IOException | URISyntaxException e) {
         LOGGER.error("Error downloading or saving the JSON schema", e);
       }
     }
   }
 
-  private static String downloadSchema(String schemaUrl) throws IOException {
+  private static String downloadSchema(String schemaUrl) throws IOException, URISyntaxException {
     StringBuilder result = new StringBuilder();
-    URL url = new URL(schemaUrl);
+    URL url = new URI(schemaUrl).toURL();
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod(RequestMethod.GET.name());
     try (BufferedReader reader = new BufferedReader(

--- a/src/main/java/eu/dissco/dataexporter/maven/MavenRunner.java
+++ b/src/main/java/eu/dissco/dataexporter/maven/MavenRunner.java
@@ -1,0 +1,58 @@
+package eu.dissco.dataexporter.maven;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+public class MavenRunner {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MavenRunner.class);
+
+  public static void main(String[] args) {
+    LOGGER.info("Starting the MavenRunner to download and parse json schemas");
+    for (String schemaUrl : args) {
+      LOGGER.info("Processing json schema: {}", schemaUrl);
+      var fileName = schemaUrl.substring(schemaUrl.lastIndexOf('/') + 1);
+      String outputFilePath = "src/main/resources/json-schema/" + fileName;
+      try {
+        String schema = downloadSchema(schemaUrl);
+        saveSchemaToFile(schema, outputFilePath);
+        LOGGER.info("JSON schema downloaded and saved to: {} ", outputFilePath);
+      } catch (IOException e) {
+        LOGGER.error("Error downloading or saving the JSON schema", e);
+      }
+    }
+  }
+
+  private static String downloadSchema(String schemaUrl) throws IOException {
+    StringBuilder result = new StringBuilder();
+    URL url = new URL(schemaUrl);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestMethod(RequestMethod.GET.name());
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        result.append(line).append("\n");
+      }
+    }
+    return result.toString();
+  }
+
+  private static void saveSchemaToFile(String schema, String filePath) throws IOException {
+    try (BufferedWriter writer = new BufferedWriter(
+        new OutputStreamWriter(new FileOutputStream(filePath), StandardCharsets.UTF_8))) {
+      writer.write(schema);
+    }
+  }
+
+}

--- a/src/main/java/eu/dissco/dataexporter/service/DataExporterService.java
+++ b/src/main/java/eu/dissco/dataexporter/service/DataExporterService.java
@@ -11,7 +11,7 @@ import eu.dissco.dataexporter.domain.User;
 import eu.dissco.dataexporter.exception.InvalidRequestException;
 import eu.dissco.dataexporter.repository.DataExporterRepository;
 import eu.dissco.dataexporter.schema.Attributes;
-import eu.dissco.dataexporter.schema.ExportJobRequest;
+import eu.dissco.dataexporter.schema.DataExportRequest;
 import eu.dissco.dataexporter.schema.SearchParam;
 import java.security.MessageDigest;
 import java.time.Instant;
@@ -31,7 +31,7 @@ public class DataExporterService {
   private final ObjectMapper mapper;
   private final MessageDigest messageDigest;
 
-  public void handleJobRequest(ExportJobRequest jobRequest, User user)
+  public void handleJobRequest(DataExportRequest jobRequest, User user)
       throws InvalidRequestException {
     var params = jobRequest.getData().getAttributes().getSearchParams();
     var hashedParams = hashParams(params);

--- a/src/main/resources/json-schema/data-export-request.json
+++ b/src/main/resources/json-schema/data-export-request.json
@@ -55,7 +55,7 @@
           },
           "additionalProperties": false,
           "required": [
-            "params",
+            "searchParams",
             "targetType",
             "exportType"
           ]

--- a/src/test/java/eu/dissco/dataexporter/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/dataexporter/utils/TestUtils.java
@@ -13,7 +13,7 @@ import eu.dissco.dataexporter.domain.User;
 import eu.dissco.dataexporter.schema.Attributes;
 import eu.dissco.dataexporter.schema.Attributes.ExportType;
 import eu.dissco.dataexporter.schema.Data;
-import eu.dissco.dataexporter.schema.ExportJobRequest;
+import eu.dissco.dataexporter.schema.DataExportRequest;
 import eu.dissco.dataexporter.schema.SearchParam;
 import java.time.Instant;
 import java.util.Date;
@@ -53,8 +53,8 @@ public class TestUtils {
         "email", EMAIL);
   }
 
-  public static ExportJobRequest givenJobRequest() {
-    return new ExportJobRequest().withData(new Data()
+  public static DataExportRequest givenJobRequest() {
+    return new DataExportRequest().withData(new Data()
         .withType("export-job")
         .withAttributes(new Attributes()
             .withExportType(ExportType.DOI_LIST)


### PR DESCRIPTION
- use schema from schemas.dissco.tech
- update spring boot
- change routing slightly: now the `data-export` is removed by the stripprefix middleware ([see deployment pr](https://github.com/DiSSCo/dissco-core-deployment/pull/81))

