### PR TITLE
swagger endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,15 +31,16 @@
     <url/>
   </scm>
   <properties>
+    <aws-sdk.version>2.28.21</aws-sdk.version>
     <java.version>21</java.version>
+    <k8s-client-java.version>21.0.1</k8s-client-java.version>
+    <mockito-inline.version>5.2.0</mockito-inline.version>
     <sonar.organization>dissco</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>../app-it/target/site/jacoco-aggregate/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
+    <springdoc.version>2.7.0</springdoc.version>
     <testcontainers.version>1.19.8</testcontainers.version>
-    <mockito-inline.version>5.2.0</mockito-inline.version>
-    <aws-sdk.version>2.28.21</aws-sdk.version>
-    <k8s-client-java.version>21.0.1</k8s-client-java.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -101,6 +102,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>${springdoc.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/src/main/java/eu/dissco/dataexporter/controller/DataExporterController.java
+++ b/src/main/java/eu/dissco/dataexporter/controller/DataExporterController.java
@@ -7,6 +7,10 @@ import eu.dissco.dataexporter.exception.ForbiddenException;
 import eu.dissco.dataexporter.exception.InvalidRequestException;
 import eu.dissco.dataexporter.schema.DataExportRequest;
 import eu.dissco.dataexporter.service.DataExporterService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,20 +20,26 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Controller
-@RequestMapping("/")
 @Slf4j
+@RestController
+@RequestMapping("/")
 @RequiredArgsConstructor
+@RestControllerAdvice
 public class DataExporterController {
 
   private final DataExporterService service;
 
-  @PostMapping("schedule")
+
+  @Operation(summary = "Schedule a download job")
+  @PostMapping(value = "schedule", consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> scheduleJob(Authentication authentication,
       @RequestBody DataExportRequest request)
       throws ForbiddenException, InvalidRequestException {
@@ -39,6 +49,7 @@ public class DataExporterController {
     return ResponseEntity.status(HttpStatus.ACCEPTED).build();
   }
 
+  @Operation(summary = "Update a job state to running/failed. Used by data export job", hidden = true)
   @PostMapping("internal/{id}/{jobState}")
   public ResponseEntity<Void> updateJobState(@PathVariable("id") UUID id,
       @PathVariable("jobState") String jobStateStr) throws InvalidRequestException {
@@ -47,6 +58,7 @@ public class DataExporterController {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
+  @Operation(summary = "Update a job state to completed. Used by data export job", hidden = true)
   @PostMapping(value = "internal/completed", consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> completeJob(@RequestBody JobResult jobResult) {
     service.markJobAsComplete(jobResult);


### PR DESCRIPTION
Adds swagger documentation

fyi: our previous version of spring docs isn't compatible with spring boot 3.4. Had to upgrade to openapi 2.7 and explicitly state the swagger endpoint using `springdoc.swagger-ui.path=/swagger-ui.html` in application. 