### PR TITLE
Secrets should be environment agnostic ! Deployment Changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
@@ -18,13 +18,13 @@ jobs:
         with:
           java-version: 21
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -39,7 +39,7 @@ jobs:
           -Dsonar.coverage.exclusions=**/properties/**,**/configuration/**,**/maven/**
       - name: Login to Public ECR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/dataexporter/component/JobSchedulerComponent.java
+++ b/src/main/java/eu/dissco/dataexporter/component/JobSchedulerComponent.java
@@ -5,6 +5,7 @@ import eu.dissco.dataexporter.database.jooq.enums.JobState;
 import eu.dissco.dataexporter.domain.ExportJob;
 import eu.dissco.dataexporter.exception.SchedulingFailedRuntimeException;
 import eu.dissco.dataexporter.properties.JobProperties;
+import eu.dissco.dataexporter.properties.TokenProperties;
 import eu.dissco.dataexporter.repository.DataExporterRepository;
 import eu.dissco.dataexporter.schema.SearchParam;
 import freemarker.template.Template;
@@ -34,6 +35,7 @@ public class JobSchedulerComponent {
   private final BatchV1Api batchV1Api;
   @Qualifier("yamlMapper")
   private final ObjectMapper yamlMapper;
+  private final TokenProperties tokenProperties;
 
   @Scheduled(fixedRate = 3600)
   public void schedule(){
@@ -83,6 +85,8 @@ public class JobSchedulerComponent {
     map.put("inputValues", getParamTermList(exportJob, true));
     map.put("inputFields", getParamTermList(exportJob, false));
     map.put("targetType", exportJob.targetType().getName());
+    map.put("tokenIdName", tokenProperties.getIdName());
+    map.put("tokenSecretName", tokenProperties.getSecretName());
     return map;
   }
 

--- a/src/main/java/eu/dissco/dataexporter/properties/TokenProperties.java
+++ b/src/main/java/eu/dissco/dataexporter/properties/TokenProperties.java
@@ -1,5 +1,6 @@
 package eu.dissco.dataexporter.properties;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -9,7 +10,9 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties("token")
 public class TokenProperties {
 
+  @NotBlank
   private String secretName;
+  @NotBlank
   private String idName;
 
 }

--- a/src/main/java/eu/dissco/dataexporter/properties/TokenProperties.java
+++ b/src/main/java/eu/dissco/dataexporter/properties/TokenProperties.java
@@ -1,0 +1,15 @@
+package eu.dissco.dataexporter.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+@ConfigurationProperties("token")
+public class TokenProperties {
+
+  private String secretName;
+  private String idName;
+
+}

--- a/src/main/resources/templates/export-job.ftl
+++ b/src/main/resources/templates/export-job.ftl
@@ -39,7 +39,7 @@ spec:
             - name: token.grant-type
               value: client_credentials
             - name: token.id
-              value: production-dissco-data-export-job
+              value: ${tokenIdName}
             - name: s3.bucket-name
               value: ${bucketName}
             - name: s3.access-key
@@ -56,7 +56,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: aws-secrets
-                  key: production-dissco-data-export-job-token
+                  key: ${tokenSecretName}
             - name: elasticsearch.hostname
               value: elastic-search-es-http.elastic.svc.cluster.local
             - name: elasticsearch.port

--- a/src/test/java/eu/dissco/dataexporter/component/JobSchedulerComponentTest.java
+++ b/src/test/java/eu/dissco/dataexporter/component/JobSchedulerComponentTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.dataexporter.database.jooq.enums.JobState;
 import eu.dissco.dataexporter.domain.TargetType;
 import eu.dissco.dataexporter.properties.JobProperties;
+import eu.dissco.dataexporter.properties.TokenProperties;
 import eu.dissco.dataexporter.repository.DataExporterRepository;
 import freemarker.template.Template;
 import io.kubernetes.client.openapi.ApiException;
@@ -40,6 +41,8 @@ class JobSchedulerComponentTest {
   private JobProperties jobProperties;
   @Mock
   private ObjectMapper mockYamlMapper;
+  @Mock
+  private TokenProperties tokenProperties;
   private JobSchedulerComponent jobScheduler;
 
   private static final Integer JOB_QUEUE_SIZE = 3;
@@ -48,7 +51,7 @@ class JobSchedulerComponentTest {
   @BeforeEach
   void setup() {
     jobScheduler = new JobSchedulerComponent(repository, jobProperties, jobTemplate,
-        batchV1Api, mockYamlMapper);
+        batchV1Api, mockYamlMapper, tokenProperties);
     given(jobProperties.getQueueSize()).willReturn(JOB_QUEUE_SIZE);
   }
 
@@ -90,6 +93,8 @@ class JobSchedulerComponentTest {
     given(jobProperties.getBucketName()).willReturn("bucket");
     given(repository.getNextJobInQueue()).willReturn(Optional.of(exportJob));
     given(batchV1Api.createNamespacedJob(eq(NAMESPACE), any())).willReturn(jobRequestMock);
+    given(tokenProperties.getIdName()).willReturn("tokenIdName");
+    given(tokenProperties.getSecretName()).willReturn("tokenSecretName");
     var properties = givenExpectedTemplateProperties();
 
     // When
@@ -130,6 +135,8 @@ class JobSchedulerComponentTest {
     expectedTemplateProperties.put("inputValues", "https://ror.org/0566bfb96");
     expectedTemplateProperties.put("inputFields", "$[ods:organisationID]");
     expectedTemplateProperties.put("targetType", TargetType.DIGITAL_SPECIMEN.getName());
+    expectedTemplateProperties.put("tokenIdName", "tokenIdName");
+    expectedTemplateProperties.put("tokenSecretName", "tokenSecretName");
     return expectedTemplateProperties;
   }
 


### PR DESCRIPTION
Job secrets were environment specific. We need specify the secrets through environmental variables of the exporter backend. e.g. use "token-secret-production" as the secret store key only when this application is deployed in production. 

[Jira](https://naturalis.atlassian.net/browse/DD-1669)
