### PR TITLE
is source system job check

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,7 +1,0 @@
-# Jun 13 2025
-# Issue with postgres lib, needs a spring boot parent update
-CVE-2025-49146
-
-# Jun 18 2025
-# Issue with Tomcat, needs a spring boot parent update
-CVE-2025-48988

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>3.5.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/dataexporter/service/DataExporterService.java
+++ b/src/main/java/eu/dissco/dataexporter/service/DataExporterService.java
@@ -81,7 +81,7 @@ public class DataExporterService {
         hashedParams,
         user.email(),
         TargetType.fromString(jobAttributes.getTargetType().toString()),
-        jobAttributes.getIsSourceSystemJob(),
+        Boolean.TRUE.equals(jobAttributes.getIsSourceSystemJob()),
         null);
     checkIfJobIsValid(job);
     repository.addJobToQueue(job);


### PR DESCRIPTION
FrontEnd hasn't updated to the new data model when scheduling a new job, so `isSourceSystemJob` is null. This was throwing a NPE down the line. 

Checking it this way fixes the issue 