### PR TITLE
Give an exception if a source-system job produces no result

### DIFF
--- a/src/main/java/eu/dissco/dataexporter/service/DataExporterService.java
+++ b/src/main/java/eu/dissco/dataexporter/service/DataExporterService.java
@@ -107,8 +107,15 @@ public class DataExporterService {
     JobState jobState;
     try {
       var sourceSystemId = determineSourceSystemId(exportJob);
-      jobState = sourceSystemRepository.addDownloadLinkToJob(exportJob.exportType(), sourceSystemId,
-          jobResult.downloadLink());
+      if (jobResult.downloadLink() == null) {
+        log.error("SourceSystem Job: {} for SourceSystem: {} has not produced any result",
+            exportJob.id(), sourceSystemId);
+        jobState = JobState.FAILED;
+      } else {
+        jobState = sourceSystemRepository.addDownloadLinkToJob(exportJob.exportType(),
+            sourceSystemId,
+            jobResult.downloadLink());
+      }
     } catch (InvalidRequestException e) {
       log.error("SourceSystem Job: {} contains invalid params: {}", exportJob.id(),
           exportJob.params(), e);

--- a/src/test/java/eu/dissco/dataexporter/service/DataExporterServiceTest.java
+++ b/src/test/java/eu/dissco/dataexporter/service/DataExporterServiceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mockStatic;
 
 import eu.dissco.dataexporter.database.jooq.enums.ExportType;
 import eu.dissco.dataexporter.database.jooq.enums.JobState;
+import eu.dissco.dataexporter.domain.JobResult;
 import eu.dissco.dataexporter.exception.InvalidRequestException;
 import eu.dissco.dataexporter.repository.DataExporterRepository;
 import eu.dissco.dataexporter.repository.SourceSystemRepository;
@@ -179,6 +180,22 @@ class DataExporterServiceTest {
 
     // Then
     then(repository).should().markJobAsComplete(jobResult, JobState.COMPLETED);
+    then(emailService).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void testCompleteSourceSystemNoRecords() {
+    // Given
+    var jobResult = new JobResult(ID, null);
+    given(repository.getExportJob(ID)).willReturn(
+        givenScheduledJob(true, givenSourceSystemSearchParams(), ExportType.DWC_DP));
+
+    // When
+    service.markJobAsComplete(jobResult);
+
+    // Then
+    then(repository).should().markJobAsComplete(jobResult, JobState.FAILED);
+    then(sourceSystemRepository).shouldHaveNoInteractions();
     then(emailService).shouldHaveNoInteractions();
   }
 


### PR DESCRIPTION
Assumption is that a source system should always have some records otherwise why is it there...
